### PR TITLE
Correct dependency name for CairoSVG

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ discord.py==1.4.1
 aiomysql==0.0.20
 aioscheduler==1.4.2
 emoji==0.6.0
-cariosvg
+CairoSVG==2.4.2


### PR DESCRIPTION
CairoSVG was misspelled in requirements.txt 