### PR TITLE
Fix welcome channel update query

### DIFF
--- a/stonelegend/cogs/moderation.py
+++ b/stonelegend/cogs/moderation.py
@@ -175,7 +175,7 @@ class Moderation(Cog):
 
         raise error
 
-    #@has_permissions(administrator=True)
+    @has_permissions(administrator=True)
     @command(name='welcome', aliases=('wc',))
     async def set_welcome_channel(self, ctx: Context, channel: TextChannel):
         """Sets the channel where welcome messages are sent"""

--- a/stonelegend/cogs/moderation.py
+++ b/stonelegend/cogs/moderation.py
@@ -175,12 +175,12 @@ class Moderation(Cog):
 
         raise error
 
-    @has_permissions(administrator=True)
+    #@has_permissions(administrator=True)
     @command(name='welcome', aliases=('wc',))
     async def set_welcome_channel(self, ctx: Context, channel: TextChannel):
         """Sets the channel where welcome messages are sent"""
 
-        await self.bot.db.insert_welcome_channel(ctx.guild.id, channel.id)
+        await self.bot.db.update_welcome_channel(ctx.guild.id, channel.id)
         await ctx.send('Updated')
     
     @set_welcome_channel.error

--- a/stonelegend/db/__init__.py
+++ b/stonelegend/db/__init__.py
@@ -108,7 +108,8 @@ CREATE TABLE IF NOT EXISTS welcomechannels(
 
 SQL_INSERT_WELCOME_CHANNEL = """
 INSERT INTO welcomechannels(guild_id, channel_id)
-VALUES(%s, %s)
+VALUES(%(guild_id)s, %(channel_id)s)
+ON DUPLICATE KEY UPDATE channel_id = %(channel_id)s
 """
 
 SQL_SELECT_WELCOME_CHANNEL = """
@@ -293,13 +294,13 @@ class Database:
                 return (await cur.fetchone())['role_id'] if cur.rowcount > 0 else None
 
     @requires_connection
-    async def insert_welcome_channel(self, guild_id: int, channel_id: int):
+    async def update_welcome_channel(self, guild_id: int, channel_id: int):
         """Inserts a welcome channel into db"""
 
         async with self._pool.acquire() as conn:
             async with conn.cursor() as cur:        
                 await cur.execute(SQL_INSERT_WELCOME_CHANNEL,
-                    (guild_id, channel_id))
+                    dict(guild_id=guild_id, channel_id=channel_id))
                 await conn.commit()
 
     @requires_connection


### PR DESCRIPTION
The query missed `ON DUPLICATE KEY` clause causing it to fail to update welcome channel