### PR TITLE
Fix: purge group's kwarg invoke_without_command set to True

### DIFF
--- a/stonelegend/cogs/moderation.py
+++ b/stonelegend/cogs/moderation.py
@@ -128,7 +128,7 @@ class Moderation(Cog):
 
     @has_permissions(manage_messages=True)
     @bot_has_permissions(manage_messages=True)
-    @group(name='purge')
+    @group(name='purge', invoke_without_command=True)
     async def purge(self, ctx: Context, count: int = 10):
         """Deletes multiple messages from the current channel.
         You must have Manage messages permission."""


### PR DESCRIPTION
The base command does not execute without a sub-command being invoked if this is left out to True