### PR TITLE
Fix incorrect use of help error callbacks

### DIFF
--- a/stonelegend/help.py
+++ b/stonelegend/help.py
@@ -18,9 +18,13 @@ class CustomHelpCommand(HelpCommand):
         sig = (' ' + group.signature).rstrip()
         return f"/{group.name}{sig}"
 
-    async def command_not_found(self, string):
+    def command_not_found(self, string):
+        return f"No command called {string}!"
+
+    async def send_error_message(self, string):
         await self.get_destination().send(embed=Embed(
-            description=f"No command called {string}!",
+            title="Error",
+            description=string,
             color=Color.orange()
         ))
 


### PR DESCRIPTION
`HelpCommand.command_not_found` is called only to get the error message string while message is actually to be sent in `HelpCommand.send_error_message`. I have been sending the message in the wrong callback which causes an exception if the command is not found. (as `command_not_found` returned nothing)