### PR TITLE
Have a common aiohttp session for all requests

### DIFF
--- a/stonelegend/bot.py
+++ b/stonelegend/bot.py
@@ -1,4 +1,5 @@
 from discord.ext.commands import Bot
+import aiohttp
 
 from .help import CustomHelpCommand
 from .db import Database
@@ -10,13 +11,15 @@ class StoneLegendBot(Bot):
         super().__init__(command_prefix='/', help_command=CustomHelpCommand())
         self.sql_config = sql_config
         self.db = None
+        self.worker_http_session = aiohttp.ClientSession()
 
     # Overriden to make a db connection on start-up
     async def start(self, *args, **kwargs):
         self.db = Database(self.sql_config)
-        await self.db.connect()        
+        await self.db.connect()
         await super().start(*args, **kwargs)
 
     async def close(self, *args, **kwargs):
         await self.db.close()
+        await self.worker_http_session.close()
         await super().close()

--- a/stonelegend/cogs/info.py
+++ b/stonelegend/cogs/info.py
@@ -1,9 +1,13 @@
-from discord.ext.commands import Cog, command, Bot, Context
+from discord.ext.commands import Cog, command, Context
 from discord import Embed, Color
-import aiohttp
+
+from ..bot import StoneLegendBot
 
 
 class Info(Cog):
+
+    def __init__(self, bot: StoneLegendBot) -> None:
+        self.bot = bot
 
     @command(name='store', aliases=('shop', 'market'))
     async def store(self, ctx: Context):
@@ -33,9 +37,8 @@ class Info(Cog):
             inline=False
         )
 
-        async with aiohttp.ClientSession() as client:
-            resp = await client.get("https://api.mcsrvstat.us/2/play.stonelegend.net:19145")
-            data = await resp.json()
+        resp = await self.bot.worker_http_session.get("https://api.mcsrvstat.us/2/play.stonelegend.net:19145")
+        data = await resp.json()
 
         embed.add_field(
             name='**Status**',
@@ -56,9 +59,8 @@ class Info(Cog):
     async def players_list(self, ctx: Context):
         """Lists the online players in the MineCraft server"""
 
-        async with aiohttp.ClientSession() as client:
-            resp = await client.get("https://api.mcsrvstat.us/2/play.stonelegend.net:19145")
-            data = await resp.json()
+        resp = await self.bot.worker_http_session.get("https://api.mcsrvstat.us/2/play.stonelegend.net:19145")
+        data = await resp.json()
 
         if not data['online']:
             await ctx.send(embed=Embed(
@@ -80,5 +82,5 @@ class Info(Cog):
         ))
 
 
-def setup(bot: Bot):
-    bot.add_cog(Info())
+def setup(bot: StoneLegendBot):
+    bot.add_cog(Info(bot))

--- a/stonelegend/cogs/welcome.py
+++ b/stonelegend/cogs/welcome.py
@@ -1,6 +1,5 @@
 from discord import Member, File
 from discord.ext.commands import Cog, Context
-import aiohttp
 from concurrent.futures import ThreadPoolExecutor
 from io import BytesIO
 from base64 import b64encode
@@ -17,11 +16,9 @@ class Welcome(Cog):
             self.template_svg = fp.read()
 
         self.thread_pool = ThreadPoolExecutor(max_workers=3)
-        self.http_session = aiohttp.ClientSession()
 
     def __del__(self):
         self.thread_pool.shutdown()
-        self.http_session.close()
 
     def _generate_welcome_image(self, pfp_data, bg_data, username):
         svg = self.template_svg % dict(pfp=b64encode(pfp_data).decode('utf-8'),
@@ -49,10 +46,10 @@ class Welcome(Cog):
         if target_channel is None:
             return
 
-        async with self.http_session.get(str(member.avatar_url_as(format='png'))) as resp:
+        async with self.bot.worker_http_session.get(str(member.avatar_url_as(format='png'))) as resp:
             pfp = await resp.content.read()
 
-        async with self.http_session.get("https://source.unsplash.com/500x250/?universe") as resp:
+        async with self.bot.worker_http_session.get("https://source.unsplash.com/500x250/?universe") as resp:
             bg = await resp.content.read()
 
         image = await self.generate_welcome_image(pfp, bg, str(member))


### PR DESCRIPTION
`StoneLegendBot` now provides an instance of `aiohttp.ClientSession` which is used by cogs which require it to avoid creation of multiple client session and their respective cleanups.